### PR TITLE
feat: support `resizable` columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Yusuf <hello@iamyuu.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "gridjs": ">=3.2.0",
+    "gridjs": ">=4.0.0",
     "svelte": ">=3.30.0"
   },
   "devDependencies": {

--- a/src/gridjs.svelte
+++ b/src/gridjs.svelte
@@ -21,6 +21,7 @@
   export let height: string = "auto";
   export let autoWidth: boolean = true;
   export let fixedHeader: boolean = false;
+  export let resizable: boolean = false;
   export let from: HTMLElement = undefined;
   export let language: Language = undefined;
   export let search: SearchConfig | boolean = false;
@@ -74,6 +75,7 @@
     fixedHeader,
     style,
     className,
+    resizable,
   });
 
   instance.on('cellClick', (...args) => dispatch('cellClick', {...args}))


### PR DESCRIPTION
In Grid.js version 4.0.0, support for resizable columns was added ([see docs](https://gridjs.io/docs/examples/resizable)).
This PR exposes an additional Svelte prop, `<Grid resizable={true|false} />` (default `false`), which is passed to the `new Grid({...})` instance. 
The downside (?) is the necessary Grid.js peer dependency update in package.json. 