### PR TITLE
Adds automatic forceRender calls if config changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/svelte": "^3.0.3",
     "@tsconfig/svelte": "^1.0.10",
+    "@types/jest": "^27.0.1",
+    "@types/testing-library__jest-dom": "^5.14.1",
     "babel-jest": "^26.6.3",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",

--- a/src/gridjs.svelte
+++ b/src/gridjs.svelte
@@ -89,6 +89,25 @@
       instance.render(node);
     }
   });
+  
+  $: instance.updateConfig({
+    from,
+    data,
+    columns,
+    server,
+    search,
+    sort,
+    pagination,
+    language,
+    width,
+    height,
+    autoWidth,
+    fixedHeader,
+    style,
+    className,
+    resizable,
+  }).forceRender();
+
 </script>
 
 <article bind:this={node} />

--- a/src/gridjs.svelte
+++ b/src/gridjs.svelte
@@ -75,7 +75,7 @@
     fixedHeader,
     style,
     className,
-    resizable,
+    resizable
   });
 
   instance.on('cellClick', (...args) => dispatch('cellClick', {...args}))
@@ -107,6 +107,7 @@
         fixedHeader,
         style,
         className,
+        resizable
       })
       .forceRender();
   }

--- a/src/gridjs.svelte
+++ b/src/gridjs.svelte
@@ -89,7 +89,7 @@
       instance.render(node);
     }
   });
-  
+
   $: instance.updateConfig({
     from,
     data,

--- a/src/gridjs.svelte
+++ b/src/gridjs.svelte
@@ -90,24 +90,26 @@
     }
   });
 
-  $: instance.updateConfig({
-    from,
-    data,
-    columns,
-    server,
-    search,
-    sort,
-    pagination,
-    language,
-    width,
-    height,
-    autoWidth,
-    fixedHeader,
-    style,
-    className,
-    resizable,
-  }).forceRender();
-
+  $: if (node) {
+    instance
+      .updateConfig({
+        from,
+        data,
+        columns,
+        server,
+        search,
+        sort,
+        pagination,
+        language,
+        width,
+        height,
+        autoWidth,
+        fixedHeader,
+        style,
+        className,
+      })
+      .forceRender();
+  }
 </script>
 
 <article bind:this={node} />

--- a/src/gridjs.svelte
+++ b/src/gridjs.svelte
@@ -78,11 +78,11 @@
     resizable
   });
 
-  instance.on('cellClick', (...args) => dispatch('cellClick', {...args}))
-  instance.on('rowClick', (...args) => dispatch('rowClick', {...args}))
-  instance.on('beforeLoad', (...args) => dispatch('beforeLoad', {...args}))
-  instance.on('load', (...args) => dispatch('load', {...args}))
-  instance.on('ready', (...args) => dispatch('ready', {...args}))
+  instance.on("cellClick", (...args) => dispatch("cellClick", { ...args }));
+  instance.on("rowClick", (...args) => dispatch("rowClick", { ...args }));
+  instance.on("beforeLoad", (...args) => dispatch("beforeLoad", { ...args }));
+  instance.on("load", (...args) => dispatch("load", { ...args }));
+  instance.on("ready", (...args) => dispatch("ready", { ...args }));
 
   onMount(() => {
     if (node) {

--- a/test/gridjs.test.ts
+++ b/test/gridjs.test.ts
@@ -1,8 +1,14 @@
-import { render, screen } from '@testing-library/svelte'
-import Grid from '../src/gridjs.svelte'
+import { render, screen } from "@testing-library/svelte";
+import Grid from "../src/gridjs.svelte";
 
-test('renders the components', () => {
-  render(Grid, { props: { data: [[1, 2, 3]] } })
+test("renders the components", () => {
+  render(Grid, { props: { data: [[1, 2, 3]] } });
 
-  expect(screen.getByRole('grid')).toBeInTheDocument()
-})
+  expect(screen.getByRole("grid")).toBeInTheDocument();
+});
+
+test("re-renders the components", () => {
+  let data = [[1, 2, 3]];
+  const { debug } = render(Grid, { props: { data: [[1, 2, 3]] } });
+  debug();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["@types/jest"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules/*"]


### PR DESCRIPTION
Closes #8 

Uses `instance.updateConfig().forceRender()` when any of the props change.

I tried writing a test for this, but the existing test does not seem to actually render the rows. And installing this into my existing app had troubles as well (don't believe them to be specific to this project).