### PR TITLE
Added missing export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,11 @@
 	"bugs": {
 		"url": "https://github.com/iamyuu/gridjs-svelte/issues"
 	},
-	"homepage": "https://gridjs.io/docs/integrations/svelte"
+	"homepage": "https://gridjs.io/docs/integrations/svelte",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "svelte": "./index.js"
+    },
+  }
 }


### PR DESCRIPTION
With latest versions of Svelte, this is a new requirement: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition

This fixes #31 

If "exports" is missing in `package.json`, it throws a warning:
```
WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

gridjs-svelte@2.1.1

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
```
